### PR TITLE
Changed to version 2.0.2-SNAPSHOT. Changed devkit to version 3.9.0. I…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,18 +3,18 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.mule.modules</groupId>
     <artifactId>mule-module-cloudhub</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.2-SNAPSHOT</version>
     <packaging>mule-module</packaging>
     <name>Mule CloudHub Connector</name>
 
     <parent>
         <groupId>org.mule.tools.devkit</groupId>
         <artifactId>mule-devkit-parent</artifactId>
-        <version>3.7.2</version>
+        <version>3.9.0</version>
     </parent>
 
   	<properties>
-		<junit.version>4.9</junit.version>
+	<junit.version>4.9</junit.version>
 		<mockito.version>1.8.2</mockito.version>
 		<jdk.version>1.7</jdk.version>
 		<category>Community</category>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>com.mulesoft.cloudhub</groupId>
             <artifactId>cloudhub-client-api</artifactId>
-            <version>1.7.0-HYDRA</version>
+            <version>1.7.2-HYDRA</version>
         </dependency>
         <!-- test dependencies -->
         <dependency>

--- a/src/main/java/org/mule/modules/cloudhub/config/BasicAuthConfig.java
+++ b/src/main/java/org/mule/modules/cloudhub/config/BasicAuthConfig.java
@@ -47,6 +47,20 @@ public class BasicAuthConfig implements Config {
     @Default(value = "0")
     @FriendlyName("Maximum time allowed to deploy or undeploy.")
     private Long maxWaitTime;
+    
+    /**
+     * Specifies the amount of time, in milliseconds, that the consumer will wait for a response before it times out. Default value is 0, which means infinite.
+     */
+    @Configurable
+    @Default("0")
+    private Integer readTimeout;
+
+    /**
+     * Specifies the amount of time, in milliseconds, that the consumer will attempt to establish a connection before it times out. Default value is 0, which means infinite.
+     */
+    @Configurable
+    @Default("0")
+    private Integer connectionTimeout;
 
     /**
      * Connect
@@ -55,13 +69,15 @@ public class BasicAuthConfig implements Config {
      * @param password A password
      * @param url CloudHub URL
      * @param sandbox SandBox name
+     * @param connectionTimeout Specifies the amount of time, in milliseconds, that the consumer will attempt to establish a connection before it times out. Default value is 0, which means infinite
+     * @param readTimeout Specifies the amount of time, in milliseconds, that the consumer will wait for a response before it times out. Default value is 0, which means infinite
      * @throws ConnectionException
      */
     @Connect
     @TestConnectivity
     public void connect(@ConnectionKey String username, @Password String password, @Default("https://anypoint.mulesoft.com/cloudhub/") String url, @Optional String sandbox) throws ConnectionException {
         try {
-            cloudHubClient = new CloudHubConnectionImpl(url, username, password, sandbox, false);
+            cloudHubClient = new CloudHubConnectionImpl(url, username, password, sandbox, readTimeout, connectionTimeout, false);
             cloudHubClient.getSupportedMuleVersions();
         } catch (CloudHubException e) {
             throw new ConnectionException(ConnectionExceptionCode.INCORRECT_CREDENTIALS, e.getMessage(), e.getMessage(),e);
@@ -100,5 +116,21 @@ public class BasicAuthConfig implements Config {
 
     public CloudHubConnectionImpl getClient() {
         return cloudHubClient;
+    }
+    
+    public Integer getReadTimeout() {
+        return readTimeout;
+    }
+
+    public void setReadTimeout(Integer readTimeout) {
+        this.readTimeout = readTimeout;
+    }
+    
+    public Integer getConnectionTimeout() {
+        return connectionTimeout;
+    }
+
+    public void setConnectionTimeout(Integer connectionTimeout) {
+        this.connectionTimeout = connectionTimeout;
     }
 }

--- a/src/main/java/org/mule/modules/cloudhub/config/TokenConfig.java
+++ b/src/main/java/org/mule/modules/cloudhub/config/TokenConfig.java
@@ -34,10 +34,24 @@ public class TokenConfig implements Config {
     @Configurable
     @Default("https://anypoint.mulesoft.com/cloudhub/")
     private String url;
+    
+    /**
+     * Specifies the amount of time, in milliseconds, that the consumer will wait for a response before it times out. Default value is 0, which means infinite.
+     */
+    @Configurable
+    @Default("0")
+    private Integer readTimeout;
+
+    /**
+     * Specifies the amount of time, in milliseconds, that the consumer will attempt to establish a connection before it times out. Default value is 0, which means infinite.
+     */
+    @Configurable
+    @Default("0")
+    private Integer connectionTimeout;
 
     public CloudHubConnectionImpl getClient() {
         if(cloudHubClient == null){
-            cloudHubClient = new CloudHubConnectionImpl(url, null, null, null, false);
+            cloudHubClient = new CloudHubConnectionImpl(url, null, null, null, readTimeout, connectionTimeout, false);
     }
         return cloudHubClient;
     }
@@ -52,6 +66,22 @@ public class TokenConfig implements Config {
 
     public void setUrl(String url) {
         this.url = url;
+    }
+    
+    public Integer getReadTimeout() {
+        return readTimeout;
+    }
+
+    public void setReadTimeout(Integer readTimeout) {
+        this.readTimeout = readTimeout;
+    }
+    
+    public Integer getConnectionTimeout() {
+        return connectionTimeout;
+    }
+
+    public void setConnectionTimeout(Integer connectionTimeout) {
+        this.connectionTimeout = connectionTimeout;
     }
 
     public void setMaxWaitTime(Long maxWaitTime) {


### PR DESCRIPTION
…mplemented 'readTimeout' and 'connectionTimeout' options for the cloudhub connector to deal with server-side timeouts. Made changes to mulesoft/ion-client-api project to deal with these new options.